### PR TITLE
Update Singapore numbers to allow 800 followed by 7 digits

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -279,7 +279,10 @@ Phony.define do
   # Singapore (Republic of).
   #
   country '65',
-    none >> split(4,4) # TODO Short Codes.
+    none >> matched_split(
+        /^(800)\d{7}$/ => [3,3,4], # International Toll Free Service (ITFS) and Home Country Direct Service (HCDS) Numbers
+        /^\d{8}$/ => [4,4]         # TODO Short Codes
+    )
 
   # Thailand.
   #

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -268,6 +268,8 @@ describe 'plausibility' do
                                                ['+381 62 12 34567', '+381 62 12 3456'],
                                                ['+381 65 12 34567', '+381 65 12 3456']]
       it_is_correct_for 'Sierra Leone', :samples => '+232 42 393 972'
+      it_is_correct_for 'Singapore', :samples => ['+65 6123 1234',
+                                                  '+65 800 852 1234']
       it_is_correct_for 'Solomon Islands', :samples => '+677  97851'
       it_is_correct_for 'Somali Democratic Republic', :samples => ['+252 1034 123 45',
                                                                    '+252 1313 123',

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -661,7 +661,8 @@ describe 'country descriptions' do
     end
 
     describe 'Singapore' do
-      it_splits '6561231234', ['65', false, '6123', '1234'] # Fixed line
+      it_splits '6561231234',   ['65', false, '6123', '1234'] # Fixed line
+      it_splits '658008521234', ['65', '800', '852', '1234'] # International Toll Free Service (ITFS) and Home Country Direct Service (HCDS) Numbers
     end
     describe 'Slovakia' do
       it_splits '421912123456', ['421', '912', '123456'] # Mobile


### PR DESCRIPTION
We noticed that Singapore numbers starting with 800 and followed by 7 digits are not considered plausible, e.g. "+65 800 852 1234".

According to the [Singapore National Numbering Plan document ](https://www.imda.gov.sg/~/media/imda/files/regulation%20licensing%20and%20consultations/frameworks%20and%20policies/numbering/national%20numbering%20plan%20and%20allocation%20process/nnp_wd.pdf?la=en) page 26, "+65 800 852 1234" should be a valid number.